### PR TITLE
Project detail pages + D-hybrid project list

### DIFF
--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -1,0 +1,104 @@
+import { notFound } from 'next/navigation'
+import { Metadata } from 'next'
+import projectsData from '@/data/projectsData'
+import Image from '@/components/Image'
+import Link from '@/components/Link'
+import { genPageMetadata } from 'app/seo'
+
+export const generateStaticParams = async () => projectsData.map((p) => ({ slug: p.slug }))
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await props.params
+  const project = projectsData.find((p) => p.slug === slug)
+  if (!project) return {}
+  return genPageMetadata({ title: project.title, description: project.description })
+}
+
+export default async function ProjectPage(props: { params: Promise<{ slug: string }> }) {
+  const { slug } = await props.params
+  const project = projectsData.find((p) => p.slug === slug)
+  if (!project) return notFound()
+
+  const { title, kind, category, description, imgSrc, techStack, workflow, aiTools, demo, github } =
+    project
+
+  return (
+    <div className="pt-6 pb-16">
+      <Link href="/projects" className="text-muted hover:text-accent font-mono text-xs">
+        ← Projects
+      </Link>
+
+      <div className="mt-7 flex flex-wrap items-center gap-2.5">
+        <span className="chip">{kind}</span>
+        <span className="text-muted font-mono text-[11px] tracking-wide uppercase">
+          {category === 'game' ? 'Game' : 'App / Tool'}
+        </span>
+      </div>
+
+      <h1 className="mt-3 text-4xl font-bold tracking-[-0.03em] sm:text-5xl">{title}</h1>
+      <p className="text-muted mt-4 max-w-[60ch] font-serif text-xl leading-snug">{description}</p>
+
+      <div className="mt-7 flex flex-wrap gap-3 font-mono text-sm">
+        {demo && (
+          <a href={demo} className="ghost-btn">
+            Live Demo ↗
+          </a>
+        )}
+        {github && (
+          <a href={github} className="ghost-btn">
+            GitHub ↗
+          </a>
+        )}
+      </div>
+
+      {imgSrc && (
+        <div className="border-line bg-surface mt-10 flex aspect-[16/9] items-center justify-center overflow-hidden rounded-xl border">
+          <Image
+            src={imgSrc}
+            alt={title}
+            width={1100}
+            height={620}
+            className="h-full w-full object-contain"
+          />
+        </div>
+      )}
+
+      <div className="mt-12 grid gap-10 sm:grid-cols-3">
+        {techStack && techStack.length > 0 && (
+          <div>
+            <div className="sec-num mb-3">Tech stack</div>
+            <div className="flex flex-wrap gap-1.5">
+              {techStack.map((t) => (
+                <span key={t} className="chip">
+                  {t}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+        {workflow && workflow.length > 0 && (
+          <div>
+            <div className="sec-num mb-3">Workflow</div>
+            <ul className="text-muted space-y-1.5 font-serif text-sm">
+              {workflow.map((w) => (
+                <li key={w}>{w}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {aiTools && aiTools.length > 0 && (
+          <div>
+            <div className="sec-num mb-3">Built with AI</div>
+            <ul className="text-muted space-y-1.5 font-serif text-sm">
+              {aiTools.map((a) => (
+                <li key={a}>{a}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -11,14 +11,13 @@ export default function Projects() {
   const renderCards = (items: (typeof projectsData)[number][]) =>
     items.map((d) => (
       <Card
-        key={d.title}
+        key={d.slug}
         title={d.title}
         description={d.description}
-        href={d.href}
+        slug={d.slug}
+        kind={d.kind}
+        imgSrc={d.imgSrc}
         techStack={d.techStack}
-        aiTools={d.aiTools}
-        demo={d.demo}
-        github={d.github}
       />
     ))
 

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,53 +1,52 @@
+import Image from './Image'
 import Link from './Link'
 
 interface CardProps {
   title: string
   description: string
-  href?: string
+  slug: string
+  kind?: string
+  imgSrc?: string
   techStack?: string[]
-  aiTools?: string[]
-  demo?: string
-  github?: string
 }
 
-const Card = ({ title, description, techStack, aiTools, demo, github, href }: CardProps) => {
-  const link = demo || github || href
-  return (
-    <div className="list-row flex-col items-start sm:flex-row sm:items-baseline">
-      <div className="sm:pr-8">
-        <h2 className="text-xl font-bold tracking-tight">
-          {link ? (
-            <Link href={link} className="hover:text-accent transition-colors">
-              {title}
-            </Link>
-          ) : (
-            title
-          )}
-        </h2>
-        <p className="text-muted mt-1.5 max-w-[64ch] font-serif">{description}</p>
-        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 font-mono text-xs">
-          {demo && (
-            <Link href={demo} className="text-accent">
-              Live Demo ↗
-            </Link>
-          )}
-          {github && (
-            <Link href={github} className="text-muted hover:text-accent">
-              GitHub ↗
-            </Link>
-          )}
-          {aiTools?.length ? (
-            <span className="text-muted">built with {aiTools.join(', ')}</span>
-          ) : null}
+const Card = ({ title, description, slug, kind, imgSrc, techStack }: CardProps) => (
+  <Link
+    href={`/projects/${slug}`}
+    className="border-line group flex items-center gap-4 border-b py-4 no-underline sm:gap-6"
+  >
+    <div className="border-line bg-surface h-14 w-20 shrink-0 overflow-hidden rounded-md border">
+      {imgSrc ? (
+        <Image
+          src={imgSrc}
+          alt={title}
+          width={80}
+          height={56}
+          className="h-full w-full object-cover"
+        />
+      ) : (
+        <div className="text-muted flex h-full w-full items-center justify-center font-mono text-base font-bold">
+          {title.slice(0, 2)}
         </div>
-      </div>
-      {techStack && (
-        <span className="text-muted mt-2 shrink-0 font-mono text-xs whitespace-nowrap sm:mt-0">
-          {techStack.slice(0, 4).join(' · ')}
-        </span>
       )}
     </div>
-  )
-}
+    <div className="min-w-0 flex-1">
+      <div className="flex flex-wrap items-center gap-2">
+        <h3 className="group-hover:text-accent text-lg font-bold tracking-tight transition-colors">
+          {title}
+        </h3>
+        {kind && <span className="chip">{kind}</span>}
+      </div>
+      <p className="text-muted mt-1 line-clamp-1 max-w-[60ch] font-serif text-sm sm:line-clamp-none">
+        {description}
+      </p>
+    </div>
+    {techStack && (
+      <span className="text-muted hidden shrink-0 self-center font-mono text-xs whitespace-nowrap md:block">
+        {techStack.slice(0, 3).join(' · ')} →
+      </span>
+    )}
+  </Link>
+)
 
 export default Card

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -6,7 +6,7 @@ export default function Footer() {
     <footer className="site-chrome-footer border-line mt-16 border-t">
       <div className="text-muted flex flex-col gap-4 py-7 font-mono text-xs sm:flex-row sm:items-center sm:justify-between">
         <span>
-          © {new Date().getFullYear()} {siteMetadata.author} — hand-built, no template energy.
+          © {new Date().getFullYear()} {siteMetadata.author}
         </span>
         <div className="flex items-center gap-4">
           <SocialIcon kind="mail" href={`mailto:${siteMetadata.email}`} size={5} />

--- a/components/home/ProjectsSection.tsx
+++ b/components/home/ProjectsSection.tsx
@@ -1,4 +1,5 @@
 import Link from '@/components/Link'
+import Card from '@/components/Card'
 import projectsData from '@/data/projectsData'
 
 export default function ProjectsSection() {
@@ -12,30 +13,17 @@ export default function ProjectsSection() {
         </Link>
       </div>
       <div>
-        {featured.map((p) => {
-          const link = p.demo || p.github || p.href
-          return (
-            <div key={p.title} className="list-row">
-              <div>
-                <h3 className="text-xl font-bold">
-                  {link ? (
-                    <Link href={link} className="hover:text-accent transition-colors">
-                      {p.title}
-                    </Link>
-                  ) : (
-                    p.title
-                  )}
-                </h3>
-                <p className="text-muted mt-1 font-serif text-base">{p.description}</p>
-              </div>
-              {p.techStack && (
-                <span className="text-muted shrink-0 pt-1 font-mono text-xs whitespace-nowrap">
-                  {p.techStack.slice(0, 3).join(' · ')} →
-                </span>
-              )}
-            </div>
-          )
-        })}
+        {featured.map((p) => (
+          <Card
+            key={p.slug}
+            title={p.title}
+            description={p.description}
+            slug={p.slug}
+            kind={p.kind}
+            imgSrc={p.imgSrc}
+            techStack={p.techStack}
+          />
+        ))}
       </div>
     </section>
   )

--- a/data/projectsData.ts
+++ b/data/projectsData.ts
@@ -1,5 +1,7 @@
 interface Project {
   title: string
+  slug: string
+  kind: string
   description: string
   category: 'game' | 'non-game'
   href?: string
@@ -15,6 +17,8 @@ interface Project {
 const projectsData: Project[] = [
   {
     title: 'More Munch',
+    slug: 'more-munch',
+    kind: 'Web Service',
     description:
       'A lunch-recommendation service for office workers. It auto-collects nearby restaurants (discoverable via the OpenClaw skill-optimized API) and suggests a fresh lunch every day based on your visit history and ratings.',
     category: 'non-game',
@@ -33,6 +37,8 @@ const projectsData: Project[] = [
   },
   {
     title: 'CheerCat',
+    slug: 'cheercat',
+    kind: 'Mobile App',
     description:
       'A daily journaling app that builds the habit of praising yourself every day — a small ritual for a positive mindset.',
     category: 'non-game',
@@ -43,6 +49,8 @@ const projectsData: Project[] = [
   },
   {
     title: 'Earth Invaders',
+    slug: 'earth-invaders',
+    kind: 'Arcade Game',
     description:
       'A Phaser3 arcade shooter. Fend off the aliens invading Earth, classic arcade style.',
     category: 'game',
@@ -55,6 +63,8 @@ const projectsData: Project[] = [
   },
   {
     title: 'Fish Tank Simulator',
+    slug: 'fish-tank-simulator',
+    kind: 'Idle Game',
     description:
       'A pixel-art idle productivity tool that blends a Pomodoro timer with an aquarium sim. Complete focus sessions to earn fish eggs, collect 12+ species, and grow your own tank.',
     category: 'game',
@@ -67,6 +77,8 @@ const projectsData: Project[] = [
   },
   {
     title: 'Shoulder Check',
+    slug: 'shoulder-check',
+    kind: 'Web App',
     description:
       'A web app to calculate and track bag weight — a smart bag-weight checker for healthier shoulders.',
     category: 'non-game',
@@ -77,6 +89,8 @@ const projectsData: Project[] = [
   },
   {
     title: 'First Defense',
+    slug: 'first-defense',
+    kind: 'Tower Defense',
     description:
       'A 2.5D roguelite tower-defense prototype built in Godot 4.6, designed around unit combos, tag synergies, real-time placement, and meta-progression.',
     category: 'game',
@@ -90,6 +104,8 @@ const projectsData: Project[] = [
   },
   {
     title: 'Side Project Tracker',
+    slug: 'side-project-tracker',
+    kind: 'macOS App',
     description:
       'A macOS desktop app that tracks all your side projects in one window. For each GitHub repo it surfaces release stage, staleness detection, interest tags, and mood-matching, using the authenticated gh CLI and local git as data sources. Ships with an English/Korean UI.',
     category: 'non-game',


### PR DESCRIPTION
## Summary

- **Per-project detail pages:** new static `/projects/[slug]` route (`generateStaticParams` for all 7 projects) with an editorial detail layout — type label + category, title, serif description, hero image, and Tech stack / Workflow / Built-with-AI sections plus Live Demo / GitHub buttons.
- **D-hybrid list:** the projects list and the home Projects section now render rows with a **thumbnail + type-label chip + title**, and the whole row links into the project's detail page. Both reuse the `Card` component (DRY). Existing `imgSrc` files are used as thumbnails; the one project without an image falls back to an initials tile.
- **Data:** added `slug` and `kind` (type label) to each project in `projectsData.ts`.
- **Footer:** removed the "hand-built, no template energy." tagline.

## Test plan

- [x] `yarn build` — static export OK; all 7 `/projects/<slug>` pages generated
- [x] Built output verified: detail pages contain title/kind/image/links/sections; list & home link to detail; footer tagline gone
- [ ] Live visual confirmation pending deploy (local headless browser was unavailable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)