### PR TITLE
i18n framework: bilingual posts (EN canonical / KO toggle)

### DIFF
--- a/app/ko/posts/[...slug]/page.tsx
+++ b/app/ko/posts/[...slug]/page.tsx
@@ -1,10 +1,10 @@
 import 'katex/dist/katex.css'
 import { allCoreContent } from 'pliny/utils/contentlayer'
 import { Metadata } from 'next'
-import siteMetadata from '@/data/siteMetadata'
 import { notFound } from 'next/navigation'
 import { allBlogs } from '.contentlayer/generated'
-import { canonicalBlogs, postBySlug, hasBothLanguages } from '@/lib/posts'
+import { canonicalBlogs, postBySlug } from '@/lib/posts'
+import { buildPostMetadata } from '@/lib/postMeta'
 import PostView from '@/components/PostView'
 
 export async function generateMetadata(props: {
@@ -14,24 +14,15 @@ export async function generateMetadata(props: {
   const slug = decodeURI(slugArr.join('/'))
   const post = postBySlug(slug, 'ko')
   if (!post) return
-  const both = hasBothLanguages(slug)
-  return {
-    title: post.title,
-    description: post.summary,
-    alternates: both
-      ? {
-          languages: {
-            en: `${siteMetadata.siteUrl}/posts/${slug}`,
-            ko: `${siteMetadata.siteUrl}/ko/posts/${slug}`,
-            'x-default': `${siteMetadata.siteUrl}/posts/${slug}`,
-          },
-        }
-      : undefined,
-  }
+  return buildPostMetadata(post)
 }
 
-export const generateStaticParams = async () =>
-  allBlogs.filter((p) => p.language === 'ko').map((p) => ({ slug: p.slug.split('/') }))
+export const generateStaticParams = async () => {
+  const isProduction = process.env.NODE_ENV === 'production'
+  return allBlogs
+    .filter((p) => p.language === 'ko' && (!isProduction || !p.draft))
+    .map((p) => ({ slug: p.slug.split('/') }))
+}
 
 export default async function Page(props: { params: Promise<{ slug: string[] }> }) {
   const { slug: slugArr } = await props.params

--- a/app/ko/posts/[...slug]/page.tsx
+++ b/app/ko/posts/[...slug]/page.tsx
@@ -1,0 +1,44 @@
+import 'katex/dist/katex.css'
+import { allCoreContent } from 'pliny/utils/contentlayer'
+import { Metadata } from 'next'
+import siteMetadata from '@/data/siteMetadata'
+import { notFound } from 'next/navigation'
+import { allBlogs } from '.contentlayer/generated'
+import { canonicalBlogs, postBySlug, hasBothLanguages } from '@/lib/posts'
+import PostView from '@/components/PostView'
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug: string[] }>
+}): Promise<Metadata | undefined> {
+  const { slug: slugArr } = await props.params
+  const slug = decodeURI(slugArr.join('/'))
+  const post = postBySlug(slug, 'ko')
+  if (!post) return
+  const both = hasBothLanguages(slug)
+  return {
+    title: post.title,
+    description: post.summary,
+    alternates: both
+      ? {
+          languages: {
+            en: `${siteMetadata.siteUrl}/posts/${slug}`,
+            ko: `${siteMetadata.siteUrl}/ko/posts/${slug}`,
+            'x-default': `${siteMetadata.siteUrl}/posts/${slug}`,
+          },
+        }
+      : undefined,
+  }
+}
+
+export const generateStaticParams = async () =>
+  allBlogs.filter((p) => p.language === 'ko').map((p) => ({ slug: p.slug.split('/') }))
+
+export default async function Page(props: { params: Promise<{ slug: string[] }> }) {
+  const { slug: slugArr } = await props.params
+  const slug = decodeURI(slugArr.join('/'))
+  const post = postBySlug(slug, 'ko')
+  if (!post) return notFound()
+  const list = allCoreContent(canonicalBlogs())
+  const i = list.findIndex((p) => p.slug === slug)
+  return <PostView post={post} prev={list[i + 1]} next={list[i - 1]} />
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
-import { sortPosts, allCoreContent } from 'pliny/utils/contentlayer'
-import { allBlogs } from '.contentlayer/generated'
+import { allCoreContent } from 'pliny/utils/contentlayer'
+import { canonicalBlogs } from '@/lib/posts'
 import Masthead from '@/components/home/Masthead'
 import ProjectsSection from '@/components/home/ProjectsSection'
 import WritingSection from '@/components/home/WritingSection'
@@ -7,7 +7,7 @@ import ExperienceSection from '@/components/home/ExperienceSection'
 import ContactSection from '@/components/home/ContactSection'
 
 export default async function Page() {
-  const posts = allCoreContent(sortPosts(allBlogs))
+  const posts = allCoreContent(canonicalBlogs())
   return (
     <>
       <Masthead />

--- a/app/posts/[...slug]/page.tsx
+++ b/app/posts/[...slug]/page.tsx
@@ -1,9 +1,9 @@
 import 'katex/dist/katex.css'
 import { allCoreContent } from 'pliny/utils/contentlayer'
 import { Metadata } from 'next'
-import siteMetadata from '@/data/siteMetadata'
 import { notFound } from 'next/navigation'
-import { canonicalBlogs, postBySlug, hasBothLanguages } from '@/lib/posts'
+import { canonicalBlogs, postBySlug } from '@/lib/posts'
+import { buildPostMetadata } from '@/lib/postMeta'
 import PostView from '@/components/PostView'
 
 export async function generateMetadata(props: {
@@ -13,31 +13,7 @@ export async function generateMetadata(props: {
   const slug = decodeURI(slugArr.join('/'))
   const post = postBySlug(slug)
   if (!post) return
-  const both = hasBothLanguages(slug)
-  return {
-    title: post.title,
-    description: post.summary,
-    keywords: post.tags,
-    alternates: both
-      ? {
-          languages: {
-            en: `${siteMetadata.siteUrl}/posts/${slug}`,
-            ko: `${siteMetadata.siteUrl}/ko/posts/${slug}`,
-            'x-default': `${siteMetadata.siteUrl}/posts/${slug}`,
-          },
-        }
-      : undefined,
-    openGraph: {
-      title: post.title,
-      description: post.summary,
-      siteName: siteMetadata.title,
-      locale: post.language === 'en' ? 'en_US' : 'ko_KR',
-      type: 'article',
-      url: './',
-      images: [siteMetadata.socialBanner],
-    },
-    twitter: { card: 'summary_large_image', title: post.title, description: post.summary },
-  }
+  return buildPostMetadata(post)
 }
 
 export const generateStaticParams = async () =>

--- a/app/posts/[...slug]/page.tsx
+++ b/app/posts/[...slug]/page.tsx
@@ -1,122 +1,54 @@
 import 'katex/dist/katex.css'
-
-import PageTitle from '@/components/PageTitle'
-import { components } from '@/components/MDXComponents'
-import { MDXLayoutRenderer } from 'pliny/mdx-components'
-import { sortPosts, coreContent, allCoreContent } from 'pliny/utils/contentlayer'
-import { allBlogs, allAuthors } from '.contentlayer/generated'
-import type { Authors, Blog } from '.contentlayer/generated'
-import PostSimple from '@/layouts/PostSimple'
-import PostLayout from '@/layouts/PostLayout'
-import PostBanner from '@/layouts/PostBanner'
+import { allCoreContent } from 'pliny/utils/contentlayer'
 import { Metadata } from 'next'
 import siteMetadata from '@/data/siteMetadata'
 import { notFound } from 'next/navigation'
-
-const defaultLayout = 'PostLayout'
-const layouts = {
-  PostSimple,
-  PostLayout,
-  PostBanner,
-}
+import { canonicalBlogs, postBySlug, hasBothLanguages } from '@/lib/posts'
+import PostView from '@/components/PostView'
 
 export async function generateMetadata(props: {
   params: Promise<{ slug: string[] }>
 }): Promise<Metadata | undefined> {
-  const params = await props.params
-  const slug = decodeURI(params.slug.join('/'))
-  const post = allBlogs.find((p) => p.slug === slug)
-  const authorList = post?.authors || ['default']
-  const authorDetails = authorList.map((author) => {
-    const authorResults = allAuthors.find((p) => p.slug === author)
-    return coreContent(authorResults as Authors)
-  })
-  if (!post) {
-    return
-  }
-
-  const publishedAt = new Date(post.date).toISOString()
-  const modifiedAt = new Date(post.lastmod || post.date).toISOString()
-  const authors = authorDetails.map((author) => author.name)
-  let imageList = [siteMetadata.socialBanner]
-  if (post.images) {
-    imageList = typeof post.images === 'string' ? [post.images] : post.images
-  }
-  const ogImages = imageList.map((img) => {
-    return {
-      url: img.includes('http') ? img : siteMetadata.siteUrl + img,
-    }
-  })
-
+  const { slug: slugArr } = await props.params
+  const slug = decodeURI(slugArr.join('/'))
+  const post = postBySlug(slug)
+  if (!post) return
+  const both = hasBothLanguages(slug)
   return {
     title: post.title,
     description: post.summary,
     keywords: post.tags,
+    alternates: both
+      ? {
+          languages: {
+            en: `${siteMetadata.siteUrl}/posts/${slug}`,
+            ko: `${siteMetadata.siteUrl}/ko/posts/${slug}`,
+            'x-default': `${siteMetadata.siteUrl}/posts/${slug}`,
+          },
+        }
+      : undefined,
     openGraph: {
       title: post.title,
       description: post.summary,
       siteName: siteMetadata.title,
-      locale: 'ko_KR',
+      locale: post.language === 'en' ? 'en_US' : 'ko_KR',
       type: 'article',
-      publishedTime: publishedAt,
-      modifiedTime: modifiedAt,
       url: './',
-      images: ogImages,
-      authors: authors.length > 0 ? authors : [siteMetadata.author],
+      images: [siteMetadata.socialBanner],
     },
-    twitter: {
-      card: 'summary_large_image',
-      title: post.title,
-      description: post.summary,
-      images: imageList,
-    },
+    twitter: { card: 'summary_large_image', title: post.title, description: post.summary },
   }
 }
 
-export const generateStaticParams = async () => {
-  const paths = allBlogs.map((p) => ({ slug: p.slug.split('/') }))
-
-  return paths
-}
+export const generateStaticParams = async () =>
+  canonicalBlogs().map((p) => ({ slug: p.slug.split('/') }))
 
 export default async function Page(props: { params: Promise<{ slug: string[] }> }) {
-  const params = await props.params
-  const slug = decodeURI(params.slug.join('/'))
-  // Filter out drafts in production
-  const sortedCoreContents = allCoreContent(sortPosts(allBlogs))
-  const postIndex = sortedCoreContents.findIndex((p) => p.slug === slug)
-  if (postIndex === -1) {
-    return notFound()
-  }
-
-  const prev = sortedCoreContents[postIndex + 1]
-  const next = sortedCoreContents[postIndex - 1]
-  const post = allBlogs.find((p) => p.slug === slug) as Blog
-  const authorList = post?.authors || ['default']
-  const authorDetails = authorList.map((author) => {
-    const authorResults = allAuthors.find((p) => p.slug === author)
-    return coreContent(authorResults as Authors)
-  })
-  const mainContent = coreContent(post)
-  const jsonLd = post.structuredData
-  jsonLd['author'] = authorDetails.map((author) => {
-    return {
-      '@type': 'Person',
-      name: author.name,
-    }
-  })
-
-  const Layout = layouts[post.layout || defaultLayout]
-
-  return (
-    <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-      <Layout content={mainContent} authorDetails={authorDetails} next={next} prev={prev}>
-        <MDXLayoutRenderer code={post.body.code} components={components} toc={post.toc} />
-      </Layout>
-    </>
-  )
+  const { slug: slugArr } = await props.params
+  const slug = decodeURI(slugArr.join('/'))
+  const post = postBySlug(slug)
+  if (!post) return notFound()
+  const list = allCoreContent(canonicalBlogs())
+  const i = list.findIndex((p) => p.slug === slug)
+  return <PostView post={post} prev={list[i + 1]} next={list[i - 1]} />
 }

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,6 +1,6 @@
 import ListLayout from '@/layouts/ListLayoutWithTags'
-import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
-import { allBlogs } from '.contentlayer/generated'
+import { allCoreContent } from 'pliny/utils/contentlayer'
+import { canonicalBlogs } from '@/lib/posts'
 import { genPageMetadata } from 'app/seo'
 
 const POSTS_PER_PAGE = 5
@@ -8,7 +8,7 @@ const POSTS_PER_PAGE = 5
 export const metadata = genPageMetadata({ title: 'Posts' })
 
 export default function BlogPage() {
-  const posts = allCoreContent(sortPosts(allBlogs))
+  const posts = allCoreContent(canonicalBlogs())
   const pageNumber = 1
   const initialDisplayPosts = posts.slice(
     POSTS_PER_PAGE * (pageNumber - 1),

--- a/app/posts/page/[page]/page.tsx
+++ b/app/posts/page/[page]/page.tsx
@@ -1,11 +1,11 @@
 import ListLayout from '@/layouts/ListLayoutWithTags'
-import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
-import { allBlogs } from '.contentlayer/generated'
+import { allCoreContent } from 'pliny/utils/contentlayer'
+import { canonicalBlogs } from '@/lib/posts'
 
 const POSTS_PER_PAGE = 5
 
 export const generateStaticParams = async () => {
-  const totalPages = Math.ceil(allBlogs.length / POSTS_PER_PAGE)
+  const totalPages = Math.ceil(canonicalBlogs().length / POSTS_PER_PAGE)
   const paths = Array.from({ length: totalPages }, (_, i) => ({ page: (i + 1).toString() }))
 
   return paths
@@ -13,7 +13,7 @@ export const generateStaticParams = async () => {
 
 export default async function Page(props: { params: Promise<{ page: string }> }) {
   const params = await props.params
-  const posts = allCoreContent(sortPosts(allBlogs))
+  const posts = allCoreContent(canonicalBlogs())
   const pageNumber = parseInt(params.page as string)
   const initialDisplayPosts = posts.slice(
     POSTS_PER_PAGE * (pageNumber - 1),

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,18 +1,25 @@
 import { MetadataRoute } from 'next'
-import { allBlogs } from '.contentlayer/generated'
 import siteMetadata from '@/data/siteMetadata'
+import { canonicalBlogs, hasBothLanguages } from '@/lib/posts'
 
 export const dynamic = 'force-static'
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const siteUrl = siteMetadata.siteUrl.replace(/\/+$/, '')
 
-  const blogRoutes = allBlogs
-    .filter((post) => !post.draft)
-    .map((post) => ({
-      url: `${siteUrl}/${post.path}`,
+  const blogRoutes: MetadataRoute.Sitemap = []
+  for (const post of canonicalBlogs()) {
+    blogRoutes.push({
+      url: `${siteUrl}/posts/${post.slug}`,
       lastModified: post.lastmod || post.date,
-    }))
+    })
+    if (hasBothLanguages(post.slug)) {
+      blogRoutes.push({
+        url: `${siteUrl}/ko/posts/${post.slug}`,
+        lastModified: post.lastmod || post.date,
+      })
+    }
+  }
 
   const routes = ['', 'posts', 'projects', 'tags'].map((route) => ({
     url: `${siteUrl}/${route}`,

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -1,8 +1,8 @@
 import { slug } from 'github-slugger'
-import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
+import { allCoreContent } from 'pliny/utils/contentlayer'
 import siteMetadata from '@/data/siteMetadata'
 import ListLayout from '@/layouts/ListLayoutWithTags'
-import { allBlogs } from '.contentlayer/generated'
+import { canonicalBlogs } from '@/lib/posts'
 import tagData from 'app/tag-data.json'
 import { genPageMetadata } from 'app/seo'
 import { Metadata } from 'next'
@@ -39,7 +39,7 @@ export default async function TagPage(props: { params: Promise<{ tag: string }> 
   // Capitalize first letter and convert space to dash
   const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
   const filteredPosts = allCoreContent(
-    sortPosts(allBlogs.filter((post) => post.tags && post.tags.map((t) => slug(t)).includes(tag)))
+    canonicalBlogs().filter((post) => post.tags && post.tags.map((t) => slug(t)).includes(tag))
   )
   return <ListLayout posts={filteredPosts} title={title} />
 }

--- a/app/theme-providers.tsx
+++ b/app/theme-providers.tsx
@@ -2,11 +2,12 @@
 
 import { ThemeProvider } from 'next-themes'
 import siteMetadata from '@/data/siteMetadata'
+import { LanguageProvider } from '@/components/LanguageProvider'
 
 export function ThemeProviders({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider attribute="class" defaultTheme={siteMetadata.theme} enableSystem>
-      {children}
+      <LanguageProvider>{children}</LanguageProvider>
     </ThemeProvider>
   )
 }

--- a/components/LanguageProvider.tsx
+++ b/components/LanguageProvider.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type Lang = 'en' | 'ko'
+const LanguageContext = createContext<{ lang: Lang; setLang: (l: Lang) => void }>({
+  lang: 'en',
+  setLang: () => {},
+})
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [lang, setLangState] = useState<Lang>('en')
+  useEffect(() => {
+    const stored = localStorage.getItem('lang')
+    if (stored === 'ko' || stored === 'en') setLangState(stored)
+  }, [])
+  const setLang = (l: Lang) => {
+    localStorage.setItem('lang', l)
+    setLangState(l)
+  }
+  return <LanguageContext.Provider value={{ lang, setLang }}>{children}</LanguageContext.Provider>
+}
+
+export const useLanguage = () => useContext(LanguageContext)

--- a/components/LanguageToggle.tsx
+++ b/components/LanguageToggle.tsx
@@ -1,15 +1,35 @@
 'use client'
 
+import { usePathname, useRouter } from 'next/navigation'
+import { useLanguage } from './LanguageProvider'
+
 export default function LanguageToggle() {
+  const { lang, setLang } = useLanguage()
+  const pathname = usePathname()
+  const router = useRouter()
+
+  const choose = (l: 'en' | 'ko') => {
+    setLang(l)
+    if (l === 'ko' && pathname.startsWith('/posts/')) router.push('/ko' + pathname)
+    else if (l === 'en' && pathname.startsWith('/ko/posts/'))
+      router.push(pathname.replace(/^\/ko/, ''))
+  }
+
   return (
-    <div
-      className="text-muted font-mono text-xs"
-      aria-label="Language: English (Korean toggle coming soon)"
-      title="Korean toggle coming soon"
-    >
-      <span className="text-ink font-bold">EN</span>
+    <div className="font-mono text-xs" aria-label="Reading language">
+      <button
+        onClick={() => choose('en')}
+        className={lang === 'en' ? 'text-ink font-bold' : 'text-muted'}
+      >
+        EN
+      </button>
       <span className="px-1 opacity-40">/</span>
-      <span className="cursor-not-allowed">KO</span>
+      <button
+        onClick={() => choose('ko')}
+        className={lang === 'ko' ? 'text-ink font-bold' : 'text-muted'}
+      >
+        KO
+      </button>
     </div>
   )
 }

--- a/components/PostLink.tsx
+++ b/components/PostLink.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import Link from './Link'
+import { useLanguage } from './LanguageProvider'
+
+export default function PostLink({
+  slug,
+  className,
+  children,
+  'aria-label': ariaLabel,
+}: {
+  slug: string
+  className?: string
+  children: React.ReactNode
+  'aria-label'?: string
+}) {
+  const { lang } = useLanguage()
+  const href = lang === 'ko' ? `/ko/posts/${slug}` : `/posts/${slug}`
+  return (
+    <Link href={href} className={className} aria-label={ariaLabel}>
+      {children}
+    </Link>
+  )
+}

--- a/components/PostView.tsx
+++ b/components/PostView.tsx
@@ -1,0 +1,42 @@
+import { coreContent } from 'pliny/utils/contentlayer'
+import { MDXLayoutRenderer } from 'pliny/mdx-components'
+import { components } from '@/components/MDXComponents'
+import { allAuthors } from '.contentlayer/generated'
+import type { Authors, Blog } from '.contentlayer/generated'
+import PostSimple from '@/layouts/PostSimple'
+import PostLayout from '@/layouts/PostLayout'
+import PostBanner from '@/layouts/PostBanner'
+import type { CoreContent } from 'pliny/utils/contentlayer'
+
+const layouts = { PostSimple, PostLayout, PostBanner }
+const defaultLayout = 'PostLayout'
+
+export default function PostView({
+  post,
+  prev,
+  next,
+}: {
+  post: Blog
+  prev?: CoreContent<Blog>
+  next?: CoreContent<Blog>
+}) {
+  const authorList = post.authors || ['default']
+  const authorDetails = authorList.map((a) =>
+    coreContent(allAuthors.find((p) => p.slug === a) as Authors)
+  )
+  const mainContent = coreContent(post)
+  const jsonLd = post.structuredData
+  jsonLd['author'] = authorDetails.map((a) => ({ '@type': 'Person', name: a.name }))
+  const Layout = layouts[post.layout || defaultLayout]
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Layout content={mainContent} authorDetails={authorDetails} next={next} prev={prev}>
+        <MDXLayoutRenderer code={post.body.code} components={components} toc={post.toc} />
+      </Layout>
+    </>
+  )
+}

--- a/components/home/WritingSection.tsx
+++ b/components/home/WritingSection.tsx
@@ -1,4 +1,5 @@
 import Link from '@/components/Link'
+import PostLink from '@/components/PostLink'
 import { formatDate } from 'pliny/utils/formatDate'
 import siteMetadata from '@/data/siteMetadata'
 import { CoreContent } from 'pliny/utils/contentlayer'
@@ -26,9 +27,9 @@ export default function WritingSection({ posts }: { posts: CoreContent<Blog>[] }
               {post.tags?.slice(0, 2).join(' / ')}
             </div>
             <h3 className="mt-1.5 text-2xl leading-tight font-bold tracking-tight">
-              <Link href={`/${post.path}`} className="hover:text-accent transition-colors">
+              <PostLink slug={post.slug} className="hover:text-accent transition-colors">
                 {post.title}
-              </Link>
+              </PostLink>
             </h3>
             {post.summary && (
               <p className="text-muted mt-2 max-w-[64ch] font-serif">{post.summary}</p>
@@ -39,12 +40,12 @@ export default function WritingSection({ posts }: { posts: CoreContent<Blog>[] }
       <div className="mt-8">
         {rest.map((post) => (
           <div key={post.slug} className="list-row items-baseline">
-            <Link
-              href={`/${post.path}`}
+            <PostLink
+              slug={post.slug}
               className="hover:text-accent text-[17px] font-semibold transition-colors"
             >
               {post.title}
-            </Link>
+            </PostLink>
             <span className="text-muted shrink-0 font-mono text-xs">
               {formatDate(post.date, siteMetadata.locale)}
             </span>

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -41,18 +41,19 @@ function hasMermaidBlocks(): boolean {
 
 const computedFields: ComputedFields = {
   readingTime: { type: 'json', resolve: (doc) => readingTime(doc.body.raw) },
+  language: {
+    type: 'string',
+    resolve: (doc) => (/\.en\.mdx$/.test(doc._raw.sourceFileName) ? 'en' : 'ko'),
+  },
   slug: {
     type: 'string',
-    resolve: (doc) => doc._raw.flattenedPath.replace(/^.+?(\/)/, ''),
+    resolve: (doc) => doc._raw.flattenedPath.replace(/^.+?(\/)/, '').replace(/\.en$/, ''),
   },
   path: {
     type: 'string',
-    resolve: (doc) => doc._raw.flattenedPath,
+    resolve: (doc) => doc._raw.flattenedPath.replace(/\.en$/, ''),
   },
-  filePath: {
-    type: 'string',
-    resolve: (doc) => doc._raw.sourceFilePath,
-  },
+  filePath: { type: 'string', resolve: (doc) => doc._raw.sourceFilePath },
   toc: { type: 'string', resolve: (doc) => extractTocHeadings(doc.body.raw) },
 }
 
@@ -61,15 +62,17 @@ const computedFields: ComputedFields = {
  */
 function createTagCount(allBlogs) {
   const tagCount: Record<string, number> = {}
-  allBlogs.forEach((file) => {
+  const bySlug = new Map<string, (typeof allBlogs)[number]>()
+  for (const p of allBlogs) {
+    const existing = bySlug.get(p.slug)
+    if (!existing || p.language === 'en') bySlug.set(p.slug, p)
+  }
+  const canonical = [...bySlug.values()]
+  canonical.forEach((file) => {
     if (file.tags && (!isProduction || file.draft !== true)) {
       file.tags.forEach((tag: string) => {
         const formattedTag = slug(tag)
-        if (formattedTag in tagCount) {
-          tagCount[formattedTag] += 1
-        } else {
-          tagCount[formattedTag] = 1
-        }
+        tagCount[formattedTag] = (tagCount[formattedTag] || 0) + 1
       })
     }
   })
@@ -81,9 +84,14 @@ function createSearchIndex(allBlogs) {
     siteMetadata?.search?.provider === 'kbar' &&
     siteMetadata.search.kbarConfig.searchDocumentsPath
   ) {
+    const bySlug = new Map<string, (typeof allBlogs)[number]>()
+    for (const p of allBlogs) {
+      const existing = bySlug.get(p.slug)
+      if (!existing || p.language === 'en') bySlug.set(p.slug, p)
+    }
     writeFileSync(
       `public/${siteMetadata.search.kbarConfig.searchDocumentsPath}`,
-      JSON.stringify(allCoreContent(sortPosts(allBlogs)))
+      JSON.stringify(allCoreContent(sortPosts([...bySlug.values()])))
     )
     console.log('Local search index generated...')
   }
@@ -120,7 +128,7 @@ export const Blog = defineDocumentType(() => ({
         dateModified: doc.lastmod || doc.date,
         description: doc.summary,
         image: doc.images ? doc.images[0] : siteMetadata.socialBanner,
-        url: `${siteMetadata.siteUrl}/${doc._raw.flattenedPath}`,
+        url: `${siteMetadata.siteUrl}/${doc._raw.flattenedPath.replace(/\.en$/, '')}`,
       }),
     },
   },

--- a/docs/superpowers/plans/2026-06-04-i18n-framework.md
+++ b/docs/superpowers/plans/2026-06-04-i18n-framework.md
@@ -1,0 +1,585 @@
+# i18n Framework (Bilingual Posts) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make blog posts bilingual — English canonical at `/posts/<slug>`, Korean at `/ko/posts/<slug>` — with a header EN/KO reading-preference toggle, while the site never breaks before posts are translated.
+
+**Architecture:** Language is inferred from filename (`<slug>.en.mdx` = English, `<slug>.mdx` = Korean) via a contentlayer `language` computed field; `slug`/`path` strip the `.en` so both versions share one clean slug. A `canonicalBlogs()` helper dedupes to one (English-preferred) doc per slug for all listings. Two thin route trees (`/posts`, `/ko/posts`) render a shared `PostView`. A client `LanguageProvider` (localStorage) drives a `PostLink` so post links resolve to the preferred language.
+
+**Tech Stack:** Next.js 16 (static `output: 'export'`) · contentlayer2 · React client context · next/navigation.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-i18n-framework-design.md`
+
+**Branch:** `i18n/framework` (already created; spec committed).
+
+---
+
+## Conventions
+
+- **Verification is build-based, not `next dev`.** `next dev` (turbopack) is unstable on this repo (`RangeError: Map maximum size exceeded`). Per task run `yarn lint && npx tsc --noEmit`; per phase run `yarn build`; for rendered checks, serve the static export: `python3 -m http.server 8898 --directory out` and `curl`/grep the generated HTML.
+- **Git:** the working tree has unrelated pre-existing changes (`app/kb-data.json`, untracked drafts/PNGs). **Never `git add -A` / `git commit -am`.** Stage only the files each task touches. End every commit body with:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- **Do NOT touch `/notes` (KB).**
+- **No `.en.mdx` files are created by this plan** — translation is the separate follow-up. The framework must build & behave correctly with zero English files (everything stays Korean, toggle inert), and correctly once an English file appears (verified with a temporary sample in Task 11).
+
+---
+
+## File Structure
+
+**Created**
+
+- `lib/posts.ts` — `canonicalBlogs()`, `postBySlug(slug, language?)`, `hasBothLanguages(slug)`.
+- `components/LanguageProvider.tsx` — client context (`lang` in localStorage, default `en`) + `useLanguage()`.
+- `components/PostLink.tsx` — client; resolves a post href from the preference.
+- `components/PostView.tsx` — server; shared post rendering (jsonLd + layout + MDX), used by both routes.
+- `app/ko/posts/[...slug]/page.tsx` — Korean route.
+
+**Modified**
+
+- `contentlayer.config.ts` — `language` computed field; `slug`/`path`/`structuredData` strip `.en`; dedupe tag-count & search-index to canonical.
+- `app/posts/[...slug]/page.tsx` — canonical (EN) route via `PostView`; deduped `generateStaticParams`; hreflang.
+- `app/theme-providers.tsx` — wrap children in `LanguageProvider`.
+- `components/LanguageToggle.tsx` — wire to the provider + pathname-based switch.
+- `components/Header.tsx` / `components/MobileNav.tsx` — no change needed (already render `LanguageToggle`); verify only.
+- `components/home/WritingSection.tsx`, `layouts/ListLayoutWithTags.tsx`, `layouts/PostLayout.tsx` — post links via `PostLink`.
+- `app/page.tsx`, `app/posts/page.tsx` (+ pagination), `app/tags/[tag]/page.tsx` — list from `canonicalBlogs()`.
+- `app/sitemap.ts` — add `/ko/posts/<slug>` entries.
+
+---
+
+# Phase A — Content model
+
+### Task 1: contentlayer `language` field + strip `.en` from slug/path/structuredData
+
+**Files:** Modify `contentlayer.config.ts`.
+
+- [ ] **Step 1 — In `computedFields`, add `language` and update `slug`/`path`:**
+
+```ts
+const computedFields: ComputedFields = {
+  readingTime: { type: 'json', resolve: (doc) => readingTime(doc.body.raw) },
+  language: {
+    type: 'string',
+    resolve: (doc) => (/\.en\.mdx$/.test(doc._raw.sourceFileName) ? 'en' : 'ko'),
+  },
+  slug: {
+    type: 'string',
+    resolve: (doc) => doc._raw.flattenedPath.replace(/^.+?(\/)/, '').replace(/\.en$/, ''),
+  },
+  path: {
+    type: 'string',
+    resolve: (doc) => doc._raw.flattenedPath.replace(/\.en$/, ''),
+  },
+  filePath: { type: 'string', resolve: (doc) => doc._raw.sourceFilePath },
+  toc: { type: 'string', resolve: (doc) => extractTocHeadings(doc.body.raw) },
+}
+```
+
+- [ ] **Step 2 — Fix the Blog `structuredData` url** so it never contains `.en` (use the stripped path). In the `Blog` document's `structuredData.resolve`, change the `url` line to:
+
+```ts
+url: `${siteMetadata.siteUrl}/${doc._raw.flattenedPath.replace(/\.en$/, '')}`,
+```
+
+- [ ] **Step 3 — Dedupe tag count to canonical (English-preferred).** Replace `createTagCount` body's loop source so each post is counted once. At the top of `createTagCount(allBlogs)`:
+
+```ts
+function createTagCount(allBlogs) {
+  const tagCount: Record<string, number> = {}
+  const bySlug = new Map<string, (typeof allBlogs)[number]>()
+  for (const p of allBlogs) {
+    const existing = bySlug.get(p.slug)
+    if (!existing || p.language === 'en') bySlug.set(p.slug, p)
+  }
+  const canonical = [...bySlug.values()]
+  canonical.forEach((file) => {
+    if (file.tags && (!isProduction || file.draft !== true)) {
+      file.tags.forEach((tag: string) => {
+        const formattedTag = slug(tag)
+        tagCount[formattedTag] = (tagCount[formattedTag] || 0) + 1
+      })
+    }
+  })
+  writeFileSync('./app/tag-data.json', JSON.stringify(tagCount))
+}
+```
+
+- [ ] **Step 4 — Dedupe the search index to canonical.** In `createSearchIndex`, dedupe before writing:
+
+```ts
+function createSearchIndex(allBlogs) {
+  if (
+    siteMetadata?.search?.provider === 'kbar' &&
+    siteMetadata.search.kbarConfig.searchDocumentsPath
+  ) {
+    const bySlug = new Map<string, (typeof allBlogs)[number]>()
+    for (const p of allBlogs) {
+      const existing = bySlug.get(p.slug)
+      if (!existing || p.language === 'en') bySlug.set(p.slug, p)
+    }
+    writeFileSync(
+      `public/${siteMetadata.search.kbarConfig.searchDocumentsPath}`,
+      JSON.stringify(allCoreContent(sortPosts([...bySlug.values()])))
+    )
+    console.log('Local search index generated...')
+  }
+}
+```
+
+- [ ] **Step 5 — Verify:** `yarn build`. Expected: builds; `app/tag-data.json` and `public/search.json` counts unchanged from before (no `.en.mdx` exists yet, so canonical == all). `grep -c '"language"' .contentlayer/generated/Blog/_index.json` is not required; just confirm build success.
+
+- [ ] **Step 6 — Commit:** `git add contentlayer.config.ts && git commit -m "feat(i18n): language field; strip .en from slug/path; dedupe tag/search to canonical" -m "<trailer>"`
+
+---
+
+### Task 2: `lib/posts.ts` canonical helpers
+
+**Files:** Create `lib/posts.ts`.
+
+- [ ] **Step 1:**
+
+```ts
+import { allBlogs } from '.contentlayer/generated'
+import type { Blog } from '.contentlayer/generated'
+import { sortPosts } from 'pliny/utils/contentlayer'
+
+/** One doc per slug, English preferred, sorted newest-first. */
+export function canonicalBlogs(): Blog[] {
+  const bySlug = new Map<string, Blog>()
+  for (const p of allBlogs) {
+    const existing = bySlug.get(p.slug)
+    if (!existing || p.language === 'en') bySlug.set(p.slug, p)
+  }
+  return sortPosts([...bySlug.values()]) as Blog[]
+}
+
+/** A specific language version, or the canonical (English-preferred) when language omitted. */
+export function postBySlug(slug: string, language?: 'en' | 'ko'): Blog | undefined {
+  if (language) return allBlogs.find((p) => p.slug === slug && p.language === language)
+  return (
+    allBlogs.find((p) => p.slug === slug && p.language === 'en') ||
+    allBlogs.find((p) => p.slug === slug)
+  )
+}
+
+/** True when both an English and a Korean version exist for the slug. */
+export function hasBothLanguages(slug: string): boolean {
+  return (
+    allBlogs.some((p) => p.slug === slug && p.language === 'en') &&
+    allBlogs.some((p) => p.slug === slug && p.language === 'ko')
+  )
+}
+```
+
+- [ ] **Step 2 — Verify:** `npx tsc --noEmit`.
+- [ ] **Step 3 — Commit:** `git add lib/posts.ts && git commit -m "feat(i18n): canonical post helpers" -m "<trailer>"`
+
+- [ ] **Phase A gate:** `yarn build` passes.
+
+---
+
+# Phase B — Routing
+
+### Task 3: Extract `PostView` (shared post renderer)
+
+**Files:** Create `components/PostView.tsx`. (Pulls the render logic out of the current `app/posts/[...slug]/page.tsx` so both routes share it.)
+
+- [ ] **Step 1:**
+
+```tsx
+import { coreContent } from 'pliny/utils/contentlayer'
+import { MDXLayoutRenderer } from 'pliny/mdx-components'
+import { components } from '@/components/MDXComponents'
+import { allAuthors } from '.contentlayer/generated'
+import type { Authors, Blog } from '.contentlayer/generated'
+import PostSimple from '@/layouts/PostSimple'
+import PostLayout from '@/layouts/PostLayout'
+import PostBanner from '@/layouts/PostBanner'
+import type { CoreContent } from 'pliny/utils/contentlayer'
+
+const layouts = { PostSimple, PostLayout, PostBanner }
+const defaultLayout = 'PostLayout'
+
+export default function PostView({
+  post,
+  prev,
+  next,
+}: {
+  post: Blog
+  prev?: CoreContent<Blog>
+  next?: CoreContent<Blog>
+}) {
+  const authorList = post.authors || ['default']
+  const authorDetails = authorList.map((a) =>
+    coreContent(allAuthors.find((p) => p.slug === a) as Authors)
+  )
+  const mainContent = coreContent(post)
+  const jsonLd = post.structuredData
+  jsonLd['author'] = authorDetails.map((a) => ({ '@type': 'Person', name: a.name }))
+  const Layout = layouts[post.layout || defaultLayout]
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Layout content={mainContent} authorDetails={authorDetails} next={next} prev={prev}>
+        <MDXLayoutRenderer code={post.body.code} components={components} toc={post.toc} />
+      </Layout>
+    </>
+  )
+}
+```
+
+- [ ] **Step 2 — Verify:** `npx tsc --noEmit`.
+- [ ] **Step 3 — Commit:** `git add components/PostView.tsx && git commit -m "feat(i18n): shared PostView renderer" -m "<trailer>"`
+
+---
+
+### Task 4: Rework the canonical (EN) post route
+
+**Files:** Modify `app/posts/[...slug]/page.tsx`.
+
+- [ ] **Step 1 — Replace the file** (dedup params, canonical doc, prev/next from `canonicalBlogs()`, hreflang via metadata):
+
+```tsx
+import 'katex/dist/katex.css'
+import { allCoreContent } from 'pliny/utils/contentlayer'
+import { Metadata } from 'next'
+import siteMetadata from '@/data/siteMetadata'
+import { notFound } from 'next/navigation'
+import { canonicalBlogs, postBySlug, hasBothLanguages } from '@/lib/posts'
+import PostView from '@/components/PostView'
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug: string[] }>
+}): Promise<Metadata | undefined> {
+  const { slug: slugArr } = await props.params
+  const slug = decodeURI(slugArr.join('/'))
+  const post = postBySlug(slug)
+  if (!post) return
+  const both = hasBothLanguages(slug)
+  return {
+    title: post.title,
+    description: post.summary,
+    keywords: post.tags,
+    alternates: both
+      ? {
+          languages: {
+            en: `${siteMetadata.siteUrl}/posts/${slug}`,
+            ko: `${siteMetadata.siteUrl}/ko/posts/${slug}`,
+            'x-default': `${siteMetadata.siteUrl}/posts/${slug}`,
+          },
+        }
+      : undefined,
+    openGraph: {
+      title: post.title,
+      description: post.summary,
+      siteName: siteMetadata.title,
+      locale: post.language === 'en' ? 'en_US' : 'ko_KR',
+      type: 'article',
+      url: './',
+      images: [siteMetadata.socialBanner],
+    },
+    twitter: { card: 'summary_large_image', title: post.title, description: post.summary },
+  }
+}
+
+export const generateStaticParams = async () =>
+  canonicalBlogs().map((p) => ({ slug: p.slug.split('/') }))
+
+export default async function Page(props: { params: Promise<{ slug: string[] }> }) {
+  const { slug: slugArr } = await props.params
+  const slug = decodeURI(slugArr.join('/'))
+  const post = postBySlug(slug)
+  if (!post) return notFound()
+  const list = allCoreContent(canonicalBlogs())
+  const i = list.findIndex((p) => p.slug === slug)
+  return <PostView post={post} prev={list[i + 1]} next={list[i - 1]} />
+}
+```
+
+Note: `canonicalBlogs()` is already sorted newest-first, so `list[i+1]` is older (prev) and `list[i-1]` newer (next), matching the prior behavior.
+
+- [ ] **Step 2 — Verify:** `yarn build`; then `python3 -m http.server 8898 --directory out &` and `curl -s localhost:3456 ...` → check a post renders: `grep -o "Semble" out/posts/2026-06-04-semble-architecture.html | head -1`. Kill the server.
+- [ ] **Step 3 — Commit:** `git add "app/posts/[...slug]/page.tsx" && git commit -m "feat(i18n): canonical EN post route via PostView" -m "<trailer>"`
+
+---
+
+### Task 5: Korean route
+
+**Files:** Create `app/ko/posts/[...slug]/page.tsx`.
+
+- [ ] **Step 1:**
+
+```tsx
+import 'katex/dist/katex.css'
+import { allCoreContent } from 'pliny/utils/contentlayer'
+import { Metadata } from 'next'
+import siteMetadata from '@/data/siteMetadata'
+import { notFound } from 'next/navigation'
+import { allBlogs } from '.contentlayer/generated'
+import { canonicalBlogs, postBySlug, hasBothLanguages } from '@/lib/posts'
+import PostView from '@/components/PostView'
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug: string[] }>
+}): Promise<Metadata | undefined> {
+  const { slug: slugArr } = await props.params
+  const slug = decodeURI(slugArr.join('/'))
+  const post = postBySlug(slug, 'ko')
+  if (!post) return
+  const both = hasBothLanguages(slug)
+  return {
+    title: post.title,
+    description: post.summary,
+    alternates: both
+      ? {
+          languages: {
+            en: `${siteMetadata.siteUrl}/posts/${slug}`,
+            ko: `${siteMetadata.siteUrl}/ko/posts/${slug}`,
+            'x-default': `${siteMetadata.siteUrl}/posts/${slug}`,
+          },
+        }
+      : undefined,
+  }
+}
+
+export const generateStaticParams = async () =>
+  allBlogs.filter((p) => p.language === 'ko').map((p) => ({ slug: p.slug.split('/') }))
+
+export default async function Page(props: { params: Promise<{ slug: string[] }> }) {
+  const { slug: slugArr } = await props.params
+  const slug = decodeURI(slugArr.join('/'))
+  const post = postBySlug(slug, 'ko')
+  if (!post) return notFound()
+  const list = allCoreContent(canonicalBlogs())
+  const i = list.findIndex((p) => p.slug === slug)
+  return <PostView post={post} prev={list[i + 1]} next={list[i - 1]} />
+}
+```
+
+- [ ] **Step 2 — Verify:** `yarn build`; confirm `out/ko/posts/2026-06-04-semble-architecture.html` exists and contains the Korean title.
+- [ ] **Step 3 — Commit:** `git add "app/ko/posts/[...slug]/page.tsx" && git commit -m "feat(i18n): Korean /ko/posts route" -m "<trailer>"`
+
+- [ ] **Phase B gate:** `yarn build` passes; both `/posts/<slug>` and `/ko/posts/<slug>` generate.
+
+---
+
+# Phase C — Reading preference
+
+### Task 6: LanguageProvider
+
+**Files:** Create `components/LanguageProvider.tsx`; modify `app/theme-providers.tsx`.
+
+- [ ] **Step 1 — `components/LanguageProvider.tsx`:**
+
+```tsx
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type Lang = 'en' | 'ko'
+const LanguageContext = createContext<{ lang: Lang; setLang: (l: Lang) => void }>({
+  lang: 'en',
+  setLang: () => {},
+})
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [lang, setLangState] = useState<Lang>('en')
+  useEffect(() => {
+    const stored = localStorage.getItem('lang')
+    if (stored === 'ko' || stored === 'en') setLangState(stored)
+  }, [])
+  const setLang = (l: Lang) => {
+    localStorage.setItem('lang', l)
+    setLangState(l)
+  }
+  return <LanguageContext.Provider value={{ lang, setLang }}>{children}</LanguageContext.Provider>
+}
+
+export const useLanguage = () => useContext(LanguageContext)
+```
+
+- [ ] **Step 2 — Wrap in `app/theme-providers.tsx`:**
+
+```tsx
+'use client'
+
+import { ThemeProvider } from 'next-themes'
+import siteMetadata from '@/data/siteMetadata'
+import { LanguageProvider } from '@/components/LanguageProvider'
+
+export function ThemeProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme={siteMetadata.theme} enableSystem>
+      <LanguageProvider>{children}</LanguageProvider>
+    </ThemeProvider>
+  )
+}
+```
+
+- [ ] **Step 3 — Verify:** `npx tsc --noEmit`.
+- [ ] **Step 4 — Commit:** `git add components/LanguageProvider.tsx app/theme-providers.tsx && git commit -m "feat(i18n): LanguageProvider (localStorage reading preference)" -m "<trailer>"`
+
+---
+
+### Task 7: Wire LanguageToggle
+
+**Files:** Modify `components/LanguageToggle.tsx`.
+
+- [ ] **Step 1 — Replace with the wired toggle** (sets preference; on a post page, navigates to the sibling URL):
+
+```tsx
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+import { useLanguage } from './LanguageProvider'
+
+export default function LanguageToggle() {
+  const { lang, setLang } = useLanguage()
+  const pathname = usePathname()
+  const router = useRouter()
+
+  const choose = (l: 'en' | 'ko') => {
+    setLang(l)
+    if (l === 'ko' && pathname.startsWith('/posts/')) router.push('/ko' + pathname)
+    else if (l === 'en' && pathname.startsWith('/ko/posts/'))
+      router.push(pathname.replace(/^\/ko/, ''))
+  }
+
+  return (
+    <div className="font-mono text-xs" aria-label="Reading language">
+      <button
+        onClick={() => choose('en')}
+        className={lang === 'en' ? 'text-ink font-bold' : 'text-muted'}
+      >
+        EN
+      </button>
+      <span className="px-1 opacity-40">/</span>
+      <button
+        onClick={() => choose('ko')}
+        className={lang === 'ko' ? 'text-ink font-bold' : 'text-muted'}
+      >
+        KO
+      </button>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2 — Verify:** `npx tsc --noEmit && yarn lint`.
+- [ ] **Step 3 — Commit:** `git add components/LanguageToggle.tsx && git commit -m "feat(i18n): wire EN/KO toggle to preference + sibling nav" -m "<trailer>"`
+
+---
+
+### Task 8: PostLink + swap post-link call sites
+
+**Files:** Create `components/PostLink.tsx`; modify `components/home/WritingSection.tsx`, `layouts/ListLayoutWithTags.tsx`, `layouts/PostLayout.tsx`.
+
+- [ ] **Step 1 — `components/PostLink.tsx`:**
+
+```tsx
+'use client'
+
+import Link from './Link'
+import { useLanguage } from './LanguageProvider'
+
+export default function PostLink({
+  slug,
+  className,
+  children,
+  'aria-label': ariaLabel,
+}: {
+  slug: string
+  className?: string
+  children: React.ReactNode
+  'aria-label'?: string
+}) {
+  const { lang } = useLanguage()
+  const href = lang === 'ko' ? `/ko/posts/${slug}` : `/posts/${slug}`
+  return (
+    <Link href={href} className={className} aria-label={ariaLabel}>
+      {children}
+    </Link>
+  )
+}
+```
+
+- [ ] **Step 2 — In `components/home/WritingSection.tsx`,** replace each post `<Link href={`/${post.path}`} …>` with `<PostLink slug={post.slug} …>` (import `PostLink from '@/components/PostLink'`; drop the now-unused `Link` import if no other links remain). The title link and the row link both become `PostLink`.
+
+- [ ] **Step 3 — In `layouts/ListLayoutWithTags.tsx`,** replace the post-title `<Link href={`/${path}`} …>` (the article rows) with `<PostLink slug={post.slug} …>`. Keep the tag-rail `Link`s as-is (those are tag pages, not posts). Add `import PostLink from '@/components/PostLink'`.
+
+- [ ] **Step 4 — In `layouts/PostLayout.tsx`,** the prev/next links use `/${prev.path}` / `/${next.path}`. Replace them with `<PostLink slug={prev.slug}>` / `<PostLink slug={next.slug}>` so prev/next honor the reading preference. Import `PostLink`. (Leave the `← Writing` back-link and tag links as plain `Link`.)
+
+- [ ] **Step 5 — Verify:** `yarn build` (PostLink is a client component used inside server components — that is allowed). Confirm a post page + the home + `/posts` still build and the post links point to `/posts/<slug>` in the static HTML (EN default): `grep -o "/posts/2026-06-04-semble-architecture" out/index.html | head -1`.
+- [ ] **Step 6 — Commit:** `git add components/PostLink.tsx components/home/WritingSection.tsx layouts/ListLayoutWithTags.tsx layouts/PostLayout.tsx && git commit -m "feat(i18n): preference-aware PostLink across home/list/post nav" -m "<trailer>"`
+
+---
+
+# Phase D — Listings & sitemap use canonical
+
+### Task 9: Lists from `canonicalBlogs()`
+
+**Files:** Modify `app/page.tsx`, `app/posts/page.tsx` (+ any `app/posts/page/[page]/page.tsx`), `app/tags/[tag]/page.tsx`. **Read each first.**
+
+- [ ] **Step 1 — `app/page.tsx`:** change the posts source from `allCoreContent(sortPosts(allBlogs))` to `allCoreContent(canonicalBlogs())` (import `canonicalBlogs` from `@/lib/posts`; drop now-unused `sortPosts`/`allBlogs` imports if unused).
+- [ ] **Step 2 — `app/posts/page.tsx`** (and pagination page if present): same swap — feed `ListLayoutWithTags` from `allCoreContent(canonicalBlogs())`.
+- [ ] **Step 3 — `app/tags/[tag]/page.tsx`:** change the filter source from `allBlogs` to `canonicalBlogs()`:
+
+```tsx
+const filteredPosts = allCoreContent(
+  canonicalBlogs().filter((post) => post.tags && post.tags.map((t) => slug(t)).includes(tag))
+)
+```
+
+and `generateStaticParams` for tags is driven by `tag-data.json` (already canonical from Task 1) — no change.
+
+- [ ] **Step 4 — Verify:** `yarn build`; confirm `/posts` and a `/tags/<tag>` list each post once (no duplicates) — with no `.en.mdx` yet, counts equal today's.
+- [ ] **Step 5 — Commit:** `git add app/page.tsx app/posts/page.tsx "app/tags/[tag]/page.tsx" && git commit -m "feat(i18n): list home/posts/tags from canonical blogs" -m "<trailer>"` (include the pagination page path if you changed it).
+
+---
+
+### Task 10: Sitemap adds `/ko`
+
+**Files:** Modify `app/sitemap.ts`. **Read it first.**
+
+- [ ] **Step 1 — For each post, also emit the `/ko/posts/<slug>` URL.** Where the sitemap maps blog routes, build entries from `canonicalBlogs()`: a canonical `${siteUrl}/posts/<slug>` entry plus, when `hasBothLanguages(slug)`, a `${siteUrl}/ko/posts/<slug>` entry. Import `canonicalBlogs, hasBothLanguages` from `@/lib/posts`. Keep static routes as-is. (If the file currently maps `allBlogs`, switch it to `canonicalBlogs()` to avoid duplicate slugs.)
+- [ ] **Step 2 — Verify:** `yarn build`; `grep -c "/posts/" out/sitemap.xml` is sane (no `.en` URLs; `/ko/` entries only where both languages exist — i.e. none yet).
+- [ ] **Step 3 — Commit:** `git add app/sitemap.ts && git commit -m "feat(i18n): sitemap includes /ko post URLs" -m "<trailer>"`
+
+- [ ] **Phase D gate:** `yarn build` passes.
+
+---
+
+# Phase E — Verify
+
+### Task 11: End-to-end verification (incl. a temporary English sample)
+
+**Files:** none committed (temporary sample is created then removed).
+
+- [ ] **Step 1 — Baseline (no English):** `yarn build`. Confirm: every `/posts/<slug>` serves Korean (today's behavior), `/ko/posts/<slug>` also generated, build page count ≈ today + the `/ko` tree. `grep -rn "from-blue\|\\.en\\.mdx" app components layouts lib` → no stray refs.
+- [ ] **Step 2 — Add a temporary English sample:** copy one post to `data/posts/2026-06-04-semble-architecture.en.mdx` (no real translation needed) — just change the title to `"Inside Semble (EN sample)"` and replace the body with a short English paragraph (this is throwaway). `yarn build`.
+- [ ] **Step 3 — Confirm bilingual behavior in `out/`:**
+  - `out/posts/2026-06-04-semble-architecture.html` now contains `Inside Semble (EN sample)` (canonical = English).
+  - `out/ko/posts/2026-06-04-semble-architecture.html` contains the Korean title.
+  - The canonical page's `<head>` has `hreflang="en"` and `hreflang="ko"` alternates: `grep -o 'hreflang="ko"' out/posts/2026-06-04-semble-architecture.html`.
+  - Lists/home still show the post once.
+- [ ] **Step 4 — Remove the sample:** `rm data/posts/2026-06-04-semble-architecture.en.mdx`; `yarn build` returns to baseline. (Do NOT commit the sample.)
+- [ ] **Step 5 — `/notes` invariant:** `git diff main --stat -- app/kb components/kb` is empty; `.kb-theme` region of `css/tailwind.css` unchanged.
+- [ ] **Step 6 — Final lint/build:** `yarn lint && yarn build` clean.
+
+### Task 12: Branch handoff
+
+- [ ] **Step 1 — Update spec status** to `Implemented` in the spec file; commit.
+- [ ] **Step 2 — Use superpowers:finishing-a-development-branch.** Note for the follow-up translation sub-project: the framework is now in place — adding `data/posts/<slug>.en.mdx` files is all that's needed to make posts bilingual.
+
+---
+
+## Self-Review
+
+**Spec coverage:** §3 content model → Task 1-2. §4 routing (EN canonical, /ko, hreflang, static) → Task 4-5, 10. §5 toggle/provider/PostLink → Task 6-8. §6 rollout (never-broken, inert until translated) → Task 11 Steps 1-2. §7 file map → File Structure + tasks. §8 success criteria → Task 11. §9 open items: toggle placement = header (Task 7); KO noindex vs indexed = indexed + hreflang (Task 4-5, 10); translation workflow = out of scope (Task 12 note).
+
+**Placeholder scan:** No "TBD/handle edge cases". Task 9/10 say "read each first" for files whose exact current contents vary (pagination route, sitemap shape) — the change is specified concretely (swap source to `canonicalBlogs()`, add `/ko` entries); reading first is to match the file's existing structure, not a deferral.
+
+**Type consistency:** `canonicalBlogs()/postBySlug()/hasBothLanguages()` signatures are defined in Task 2 and used identically in Tasks 4,5,9,10. `language` is `'en'|'ko'` everywhere. `PostLink` prop `slug` matches `post.slug`. `useLanguage()` returns `{lang,setLang}` used in Tasks 7,8.

--- a/docs/superpowers/specs/2026-06-04-i18n-framework-design.md
+++ b/docs/superpowers/specs/2026-06-04-i18n-framework-design.md
@@ -59,16 +59,18 @@ The blog targets global developer roles, so posts should default to **English**,
 
 ---
 
-## 5. Toggle UI
+## 5. Toggle UI — global reading preference
 
-- **Remove the global header EN/KO stub** (`components/LanguageToggle.tsx` usage in `Header.tsx` and `MobileNav.tsx`) — the site UI is English-only, so a global toggle is misleading. Delete the stub component.
-- **Per-post toggle** lives in `PostLayout` (and `PostSimple`/`PostBanner` if used by posts): shown **only when the post has both language versions**. It links to the sibling-language URL (en `/posts/<slug>` ⇄ ko `/ko/posts/<slug>`), labeled `EN / KO` with the current language marked active.
+- **Keep the header `EN / KO` toggle** (and in `MobileNav`). Default **EN**.
+- A client **`LanguageProvider`** stores the reading-language preference in `localStorage` (key `lang`, default `'en'`), wrapping the app inside the existing providers. `components/LanguageToggle.tsx` is **kept and wired** to it (not deleted).
+- **Preference-aware post links:** post links across the site (home "Selected writing", `/posts` list, tags) render through a client **`PostLink`** that resolves the href from the preference — EN → `/posts/<slug>` (canonical, English-or-fallback), KO → `/ko/posts/<slug>` (Korean, which always exists). The static HTML ships the EN href (SEO / no-JS default); the client swaps to the KO href when that preference is set.
+- **On a post page:** the toggle also navigates to the sibling-language URL and updates the preference. Both URLs always exist (Korean is always present; English once translated), so the toggle is always functional; for a not-yet-translated post the EN canonical simply shows the Korean fallback.
 
 ---
 
 ## 6. Rollout (phased, never-broken)
 
-- This framework ships first. Because no `.en.mdx` exists yet, every post's `language` is `ko`, canonical `/posts/<slug>` serves Korean (today's behavior), and no toggle shows.
+- This framework ships first. Because no `.en.mdx` exists yet, every post is Korean: canonical `/posts/<slug>` serves Korean (today's behavior) and `/ko/posts/<slug>` is the same content. The header `EN / KO` toggle is present but has no visible effect (both languages resolve to Korean) until translations land.
 - As the translation sub-project adds `<slug>.en.mdx` files, those posts' canonical flips to English and the toggle appears. "English default" becomes true incrementally (recent/important posts first).
 - The site is valid and navigable at every step.
 
@@ -79,8 +81,9 @@ The blog targets global developer roles, so posts should default to **English**,
 - `contentlayer.config.ts` — add `language` + `translationKey` computed fields; make `slug`/`path` strip trailing `.en`.
 - `app/posts/[...slug]/page.tsx` — canonical EN route: `generateStaticParams` over unique `translationKey`s; pick English-else-Korean doc; render `PostLayout`; emit hreflang.
 - **New** `app/ko/posts/[...slug]/page.tsx` — KO route: params over keys with a Korean doc; render the Korean doc.
-- `layouts/PostLayout.tsx` (+ `PostSimple.tsx`, `PostBanner.tsx`) — accept current `language` + sibling availability; render the per-post toggle + hreflang.
-- `components/Header.tsx`, `components/MobileNav.tsx` — remove the `LanguageToggle` usage. **Delete** `components/LanguageToggle.tsx`.
+- `layouts/PostLayout.tsx` (+ `PostSimple.tsx`, `PostBanner.tsx`) — receive the doc's `language`; emit `hreflang` + canonical; on a post page the header toggle switches to the sibling URL.
+- **New** `LanguageProvider` (client context; `localStorage` `lang`, default `en`) added inside `app/theme-providers.tsx` (alongside the theme provider). `components/Header.tsx` / `components/MobileNav.tsx` **keep** `LanguageToggle`, now wired to the provider.
+- **New** `components/PostLink.tsx` (client) — resolves a post href from the preference; used by `components/home/WritingSection.tsx`, `layouts/ListLayoutWithTags.tsx`, and `app/tags/[tag]` post lists in place of raw `/posts/<slug>` links.
 - `app/sitemap.ts` — add `/ko/posts/<slug>` entries.
 - Search index (`createSearchIndex` in `contentlayer.config.ts`) — index **canonical (English-or-fallback) docs only**, so the Cmd+K palette doesn't show duplicate bilingual entries.
 - Prev/next + any post listing logic — operate on **canonical docs keyed by `translationKey`** (dedupe so a post isn't listed twice).
@@ -93,6 +96,7 @@ The blog targets global developer roles, so posts should default to **English**,
 - [ ] With no `.en.mdx`: every `/posts/<slug>` serves Korean (current behavior), no toggle, build identical in spirit to today.
 - [ ] Add one sample `<slug>.en.mdx`: `/posts/<slug>` now serves English, `/ko/posts/<slug>` serves Korean, toggle appears on both and links correctly, hreflang present.
 - [ ] Lists/home/search show each post once (no bilingual duplicates).
+- [ ] Header `EN / KO` toggle persists across pages (localStorage, default EN); in KO mode, clicking a post from home/list opens its `/ko/posts/<slug>` version.
 - [ ] `/notes` (KB) untouched.
 
 ---

--- a/docs/superpowers/specs/2026-06-04-i18n-framework-design.md
+++ b/docs/superpowers/specs/2026-06-04-i18n-framework-design.md
@@ -1,7 +1,7 @@
 # i18n Framework — Bilingual Posts (EN default / KO toggle)
 
 - **Date:** 2026-06-04
-- **Status:** Design approved (brainstorming), pending implementation plan
+- **Status:** Implemented on branch `i18n/framework` (2026-06-04). Verified end-to-end via a temporary `.en.mdx` sample (canonical EN, `/ko` KO, hreflang, sitemap, single-listing) then removed; baseline (no translations) unchanged.
 - **Scope of this spec:** The bilingual **framework** only. Actually translating the ~80 Korean posts is a **separate follow-up sub-project** (subagent-driven, phased).
 - **Builds on:** the merged "Bold Editorial" redesign.
 

--- a/docs/superpowers/specs/2026-06-04-i18n-framework-design.md
+++ b/docs/superpowers/specs/2026-06-04-i18n-framework-design.md
@@ -1,0 +1,104 @@
+# i18n Framework — Bilingual Posts (EN default / KO toggle)
+
+- **Date:** 2026-06-04
+- **Status:** Design approved (brainstorming), pending implementation plan
+- **Scope of this spec:** The bilingual **framework** only. Actually translating the ~80 Korean posts is a **separate follow-up sub-project** (subagent-driven, phased).
+- **Builds on:** the merged "Bold Editorial" redesign.
+
+---
+
+## 1. Goal & Context
+
+The blog targets global developer roles, so posts should default to **English**, with the original **Korean available via a per-post toggle**. Today every post in `data/posts/*.mdx` is Korean and the route is `/posts/<slug>` (single language). The site is statically exported (`output: 'export'`, GitHub Pages), so Next's built-in i18n routing is unavailable — we build locale routing manually.
+
+### Approved product decisions
+
+- **Bilingual:** English is the default/canonical language; Korean is available via toggle.
+- **Toggle scope = post content only.** Site UI (nav, labels, buttons) stays English always — no UI-string translation.
+- **`/notes` (KB) excluded** — stays Korean, no i18n.
+
+---
+
+## 2. Scope
+
+**In scope (this spec — the framework):**
+
+- Bilingual content model in contentlayer.
+- EN-canonical + KO-prefixed routing, both statically generated.
+- Per-post language toggle + `hreflang` SEO.
+- Graceful fallback so the site never breaks while translation is incomplete.
+
+**Out of scope → follow-up sub-project:**
+
+- Translating the existing ~80 Korean posts to English (content work; subagent-driven, phased, recent/important first).
+- UI-string i18n (not wanted — UI is English-only).
+- `/notes` i18n.
+
+---
+
+## 3. Content model
+
+- Existing `data/posts/<slug>.mdx` stays **Korean** (no change, keeps working today).
+- The English version is added alongside as **`data/posts/<slug>.en.mdx`** when translated.
+- Language and pairing are **inferred from the filename** — no frontmatter changes required:
+  - `contentlayer.config.ts` adds two computed fields to `Blog`:
+    - `language`: `'en'` if `_raw.sourceFileName` ends with `.en.mdx`, else `'ko'`.
+    - `translationKey`: the post slug with any trailing `.en` removed — i.e. both `<slug>.mdx` (ko) and `<slug>.en.mdx` (en) resolve to the **same** key (e.g. `2026-06-04-semble-architecture`), pairing the two language versions.
+  - The existing `slug`/`path` computed fields must also strip a trailing `.en`, so the two versions share one clean URL (no `.en` anywhere in a URL). Because `slug` is then shared by both versions, any post lookup filters by **slug + language**.
+- _Rejected alternative:_ `posts/en/` + `posts/ko/` subfolders (cleaner separation but larger structural change and churns existing files). The `.en.mdx` suffix is the minimal-change option and requires no rename of the 80 existing files.
+
+---
+
+## 4. Routing (static export)
+
+- **English = canonical:** `/posts/<slug>`. For each `translationKey`, the canonical doc is the English version if it exists, else the Korean version (fallback). `app/posts/[...slug]/page.tsx` `generateStaticParams` iterates unique `translationKey`s.
+- **Korean = `/ko/posts/<slug>`:** a new route `app/ko/posts/[...slug]/page.tsx` that renders the Korean doc for each `translationKey` that has one (all current posts). Reuses the same `PostLayout`.
+- Both route trees are statically generated.
+- **Lists / home / projects / about / tags stay English-only** (no `/ko` variants) — the toggle is post-content-only, and these pages render English UI + (English-or-fallback) post titles.
+- **SEO:** each post page emits `<link rel="alternate" hreflang="en" href=".../posts/<slug>">` and `hreflang="ko" href=".../ko/posts/<slug>">` when both exist, plus `hreflang="x-default"` → English. `sitemap.ts` includes the `/ko/posts/<slug>` URLs.
+
+---
+
+## 5. Toggle UI
+
+- **Remove the global header EN/KO stub** (`components/LanguageToggle.tsx` usage in `Header.tsx` and `MobileNav.tsx`) — the site UI is English-only, so a global toggle is misleading. Delete the stub component.
+- **Per-post toggle** lives in `PostLayout` (and `PostSimple`/`PostBanner` if used by posts): shown **only when the post has both language versions**. It links to the sibling-language URL (en `/posts/<slug>` ⇄ ko `/ko/posts/<slug>`), labeled `EN / KO` with the current language marked active.
+
+---
+
+## 6. Rollout (phased, never-broken)
+
+- This framework ships first. Because no `.en.mdx` exists yet, every post's `language` is `ko`, canonical `/posts/<slug>` serves Korean (today's behavior), and no toggle shows.
+- As the translation sub-project adds `<slug>.en.mdx` files, those posts' canonical flips to English and the toggle appears. "English default" becomes true incrementally (recent/important posts first).
+- The site is valid and navigable at every step.
+
+---
+
+## 7. Implementation map (files)
+
+- `contentlayer.config.ts` — add `language` + `translationKey` computed fields; make `slug`/`path` strip trailing `.en`.
+- `app/posts/[...slug]/page.tsx` — canonical EN route: `generateStaticParams` over unique `translationKey`s; pick English-else-Korean doc; render `PostLayout`; emit hreflang.
+- **New** `app/ko/posts/[...slug]/page.tsx` — KO route: params over keys with a Korean doc; render the Korean doc.
+- `layouts/PostLayout.tsx` (+ `PostSimple.tsx`, `PostBanner.tsx`) — accept current `language` + sibling availability; render the per-post toggle + hreflang.
+- `components/Header.tsx`, `components/MobileNav.tsx` — remove the `LanguageToggle` usage. **Delete** `components/LanguageToggle.tsx`.
+- `app/sitemap.ts` — add `/ko/posts/<slug>` entries.
+- Search index (`createSearchIndex` in `contentlayer.config.ts`) — index **canonical (English-or-fallback) docs only**, so the Cmd+K palette doesn't show duplicate bilingual entries.
+- Prev/next + any post listing logic — operate on **canonical docs keyed by `translationKey`** (dedupe so a post isn't listed twice).
+
+---
+
+## 8. Success criteria / Verification
+
+- [ ] `yarn build` static-exports cleanly with the new `/ko/posts/...` tree.
+- [ ] With no `.en.mdx`: every `/posts/<slug>` serves Korean (current behavior), no toggle, build identical in spirit to today.
+- [ ] Add one sample `<slug>.en.mdx`: `/posts/<slug>` now serves English, `/ko/posts/<slug>` serves Korean, toggle appears on both and links correctly, hreflang present.
+- [ ] Lists/home/search show each post once (no bilingual duplicates).
+- [ ] `/notes` (KB) untouched.
+
+---
+
+## 9. Open items (resolve during implementation)
+
+- Exact toggle placement/visual in `PostLayout` (top-right of the header block vs near meta).
+- Whether `/ko` Korean posts should be `noindex` or fully indexed with hreflang (default: indexed + hreflang).
+- Translation sub-project: ordering (recent/featured first), per-post subagent workflow, and how to keep code blocks / mermaid / frontmatter intact during translation — defined in that sub-project's own spec.

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -5,6 +5,7 @@
       "@/components/*": ["components/*"],
       "@/data/*": ["data/*"],
       "@/layouts/*": ["layouts/*"],
+      "@/lib/*": ["lib/*"],
       "@/css/*": ["css/*"],
       "contentlayer/generated": ["./.contentlayer/generated"]
     }

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -6,6 +6,7 @@ import { formatDate } from 'pliny/utils/formatDate'
 import { CoreContent } from 'pliny/utils/contentlayer'
 import type { Blog } from '.contentlayer/generated'
 import Link from '@/components/Link'
+import PostLink from '@/components/PostLink'
 import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import tagData from 'app/tag-data.json'
@@ -114,9 +115,9 @@ export default function ListLayoutWithTags({
               >
                 <div className="sm:pr-8">
                   <h2 className="text-xl font-bold tracking-tight">
-                    <Link href={`/${path}`} className="hover:text-accent transition-colors">
+                    <PostLink slug={post.slug} className="hover:text-accent transition-colors">
                       {title}
-                    </Link>
+                    </PostLink>
                   </h2>
                   {summary && (
                     <p className="text-muted mt-1.5 max-w-[60ch] font-serif">{summary}</p>

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -3,6 +3,7 @@ import { CoreContent } from 'pliny/utils/contentlayer'
 import type { Blog, Authors } from '.contentlayer/generated'
 import Comments from '@/components/Comments'
 import Link from '@/components/Link'
+import PostLink from '@/components/PostLink'
 import SectionContainer from '@/components/SectionContainer'
 import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
@@ -14,8 +15,8 @@ const editUrl = (path: string) => `${siteMetadata.siteRepo}/blob/main/data/${pat
 interface LayoutProps {
   content: CoreContent<Blog>
   authorDetails: CoreContent<Authors>[]
-  next?: { path: string; title: string }
-  prev?: { path: string; title: string }
+  next?: { path: string; slug: string; title: string }
+  prev?: { path: string; slug: string; title: string }
   children: ReactNode
 }
 
@@ -109,22 +110,22 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
           {(prev || next) && (
             <div className="mt-7 flex justify-between gap-5">
               <div>
-                {prev?.path && (
+                {prev?.slug && (
                   <>
                     <div className="text-muted font-mono text-[11px]">← PREVIOUS</div>
-                    <Link href={`/${prev.path}`} className="hover:text-accent font-semibold">
+                    <PostLink slug={prev.slug} className="hover:text-accent font-semibold">
                       {prev.title}
-                    </Link>
+                    </PostLink>
                   </>
                 )}
               </div>
               <div className="text-right">
-                {next?.path && (
+                {next?.slug && (
                   <>
                     <div className="text-muted font-mono text-[11px]">NEXT →</div>
-                    <Link href={`/${next.path}`} className="hover:text-accent font-semibold">
+                    <PostLink slug={next.slug} className="hover:text-accent font-semibold">
                       {next.title}
-                    </Link>
+                    </PostLink>
                   </>
                 )}
               </div>

--- a/lib/postMeta.ts
+++ b/lib/postMeta.ts
@@ -8,6 +8,7 @@ import { hasBothLanguages } from './posts'
 export function buildPostMetadata(post: Blog): Metadata {
   const slug = post.slug
   const both = hasBothLanguages(slug)
+  const base = siteMetadata.siteUrl.replace(/\/+$/, '')
   const authorList = post.authors || ['default']
   const authors = authorList
     .map((a) => coreContent(allAuthors.find((p) => p.slug === a) as Authors)?.name)
@@ -17,7 +18,7 @@ export function buildPostMetadata(post: Blog): Metadata {
   let imageList = [siteMetadata.socialBanner]
   if (post.images) imageList = typeof post.images === 'string' ? [post.images] : post.images
   const ogImages = imageList.map((img) => ({
-    url: img.includes('http') ? img : siteMetadata.siteUrl + img,
+    url: img.includes('http') ? img : base + img,
   }))
   return {
     title: post.title,
@@ -26,9 +27,9 @@ export function buildPostMetadata(post: Blog): Metadata {
     alternates: both
       ? {
           languages: {
-            en: `${siteMetadata.siteUrl}/posts/${slug}`,
-            ko: `${siteMetadata.siteUrl}/ko/posts/${slug}`,
-            'x-default': `${siteMetadata.siteUrl}/posts/${slug}`,
+            en: `${base}/posts/${slug}`,
+            ko: `${base}/ko/posts/${slug}`,
+            'x-default': `${base}/posts/${slug}`,
           },
         }
       : undefined,

--- a/lib/postMeta.ts
+++ b/lib/postMeta.ts
@@ -1,0 +1,54 @@
+import { coreContent } from 'pliny/utils/contentlayer'
+import { allAuthors } from '.contentlayer/generated'
+import type { Authors, Blog } from '.contentlayer/generated'
+import siteMetadata from '@/data/siteMetadata'
+import { Metadata } from 'next'
+import { hasBothLanguages } from './posts'
+
+export function buildPostMetadata(post: Blog): Metadata {
+  const slug = post.slug
+  const both = hasBothLanguages(slug)
+  const authorList = post.authors || ['default']
+  const authors = authorList
+    .map((a) => coreContent(allAuthors.find((p) => p.slug === a) as Authors)?.name)
+    .filter(Boolean) as string[]
+  const publishedAt = new Date(post.date).toISOString()
+  const modifiedAt = new Date(post.lastmod || post.date).toISOString()
+  let imageList = [siteMetadata.socialBanner]
+  if (post.images) imageList = typeof post.images === 'string' ? [post.images] : post.images
+  const ogImages = imageList.map((img) => ({
+    url: img.includes('http') ? img : siteMetadata.siteUrl + img,
+  }))
+  return {
+    title: post.title,
+    description: post.summary,
+    keywords: post.tags,
+    alternates: both
+      ? {
+          languages: {
+            en: `${siteMetadata.siteUrl}/posts/${slug}`,
+            ko: `${siteMetadata.siteUrl}/ko/posts/${slug}`,
+            'x-default': `${siteMetadata.siteUrl}/posts/${slug}`,
+          },
+        }
+      : undefined,
+    openGraph: {
+      title: post.title,
+      description: post.summary,
+      siteName: siteMetadata.title,
+      locale: post.language === 'en' ? 'en_US' : 'ko_KR',
+      type: 'article',
+      publishedTime: publishedAt,
+      modifiedTime: modifiedAt,
+      url: './',
+      images: ogImages,
+      authors: authors.length ? authors : [siteMetadata.author],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.summary,
+      images: imageList,
+    },
+  }
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,0 +1,30 @@
+import { allBlogs } from '.contentlayer/generated'
+import type { Blog } from '.contentlayer/generated'
+import { sortPosts } from 'pliny/utils/contentlayer'
+
+/** One doc per slug, English preferred, sorted newest-first. */
+export function canonicalBlogs(): Blog[] {
+  const bySlug = new Map<string, Blog>()
+  for (const p of allBlogs) {
+    const existing = bySlug.get(p.slug)
+    if (!existing || p.language === 'en') bySlug.set(p.slug, p)
+  }
+  return sortPosts([...bySlug.values()]) as Blog[]
+}
+
+/** A specific language version, or the canonical (English-preferred) when language omitted. */
+export function postBySlug(slug: string, language?: 'en' | 'ko'): Blog | undefined {
+  if (language) return allBlogs.find((p) => p.slug === slug && p.language === language)
+  return (
+    allBlogs.find((p) => p.slug === slug && p.language === 'en') ||
+    allBlogs.find((p) => p.slug === slug)
+  )
+}
+
+/** True when both an English and a Korean version exist for the slug. */
+export function hasBothLanguages(slug: string): boolean {
+  return (
+    allBlogs.some((p) => p.slug === slug && p.language === 'en') &&
+    allBlogs.some((p) => p.slug === slug && p.language === 'ko')
+  )
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -4,8 +4,10 @@ import { sortPosts } from 'pliny/utils/contentlayer'
 
 /** One doc per slug, English preferred, sorted newest-first. */
 export function canonicalBlogs(): Blog[] {
+  const isProduction = process.env.NODE_ENV === 'production'
+  const source = isProduction ? allBlogs.filter((p) => !p.draft) : allBlogs
   const bySlug = new Map<string, Blog>()
-  for (const p of allBlogs) {
+  for (const p of source) {
     const existing = bySlug.get(p.slug)
     if (!existing || p.language === 'en') bySlug.set(p.slug, p)
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
       "@/layouts/*": ["layouts/*"],
       "@/css/*": ["css/*"],
       "@/hooks/*": ["hooks/*"],
+      "@/lib/*": ["lib/*"],
       "pliny/*": ["node_modules/pliny/*"],
       ".contentlayer/*": [".contentlayer/*"]
     },


### PR DESCRIPTION
## Summary

Adds the **bilingual-posts framework** (no translations yet — invisible until `.en.mdx` files are added).

- **Content model:** language inferred from filename — `<slug>.mdx` (Korean, existing) vs `<slug>.en.mdx` (English, added later). A contentlayer `language` field; `slug`/`path` strip `.en` so both share one clean slug. `lib/posts.ts` (`canonicalBlogs`, `postBySlug`, `hasBothLanguages`) dedupes listings to one English-preferred doc per slug (drafts filtered in prod).
- **Routing:** English canonical at `/posts/<slug>` (Korean fallback until translated); Korean at new `/ko/posts/<slug>`; shared `PostView`; `hreflang`/`x-default` + sitemap `/ko` entries when both languages exist.
- **Reading preference:** header `EN / KO` toggle wired to a `LanguageProvider` (localStorage, default EN). A `PostLink` makes home/list/prev-next post links resolve to the preferred language; on a post page the toggle navigates to the sibling URL. SSR ships EN hrefs (SEO/no-JS), client swaps to KO when preferred.
- Lists/home/tags/sitemap/search all enumerate **canonical** docs (no bilingual duplicates).

`/notes` (KB) untouched.

## Verification

- [x] `yarn build` static export green; per-phase spec + code-quality review (5 phases)
- [x] **End-to-end** with a temporary `.en.mdx` sample: `/posts/<slug>` served English, `/ko/posts/<slug>` Korean, `hreflang` + sitemap `/ko` present, post listed once — then removed; baseline (no translations) byte-equivalent to before
- [x] Draft posts excluded; `/notes` diff vs main empty
- Note: `yarn build` (turbopack) doesn't regenerate contentlayer locally; CI's `yarn install` postinstall does (deploys already rely on this).

## Follow-up

Translating the ~80 Korean posts to English (adding `<slug>.en.mdx` files) is the separate sub-project that turns this framework on, post by post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)