### PR TITLE
Fix EN/KO language toggle (cursor + page-aware active state)

### DIFF
--- a/components/LanguageToggle.tsx
+++ b/components/LanguageToggle.tsx
@@ -8,25 +8,37 @@ export default function LanguageToggle() {
   const pathname = usePathname()
   const router = useRouter()
 
+  const onKoPost = pathname.startsWith('/ko/posts/')
+  const onEnPost = pathname.startsWith('/posts/') && !pathname.startsWith('/posts/page/')
+  // Highlight the language actually being shown: a post detail page reflects its
+  // own language; elsewhere reflect the saved reading preference.
+  const active: 'en' | 'ko' = onKoPost ? 'ko' : onEnPost ? 'en' : lang
+
   const choose = (l: 'en' | 'ko') => {
-    setLang(l)
-    if (l === 'ko' && pathname.startsWith('/posts/')) router.push('/ko' + pathname)
-    else if (l === 'en' && pathname.startsWith('/ko/posts/'))
-      router.push(pathname.replace(/^\/ko/, ''))
+    setLang(l) // remember the reading preference (drives post links elsewhere)
+    if (l === 'ko' && onEnPost) router.push('/ko' + pathname)
+    else if (l === 'en' && onKoPost) router.push(pathname.replace(/^\/ko/, ''))
   }
 
   return (
-    <div className="font-mono text-xs" aria-label="Reading language">
+    <div
+      className="font-mono text-xs"
+      title="Reading language (switches the article on post pages)"
+    >
       <button
+        type="button"
         onClick={() => choose('en')}
-        className={lang === 'en' ? 'text-ink font-bold' : 'text-muted'}
+        aria-pressed={active === 'en'}
+        className={`cursor-pointer transition-colors ${active === 'en' ? 'text-ink font-bold' : 'text-muted hover:text-ink'}`}
       >
         EN
       </button>
-      <span className="px-1 opacity-40">/</span>
+      <span className="text-muted px-1 opacity-50">/</span>
       <button
+        type="button"
         onClick={() => choose('ko')}
-        className={lang === 'ko' ? 'text-ink font-bold' : 'text-muted'}
+        aria-pressed={active === 'ko'}
+        className={`cursor-pointer transition-colors ${active === 'ko' ? 'text-ink font-bold' : 'text-muted hover:text-ink'}`}
       >
         KO
       </button>


### PR DESCRIPTION
## Summary

Two reported issues with the header `EN / KO` toggle:

1. **Pointer cursor** — native `<button>`s showed the default arrow; added `cursor-pointer` (+ hover feedback, `type=button`, `aria-pressed`).
2. **"Doesn't work"** — the active highlight was driven by the *stored preference*, not the page being viewed. So on an English post page whose stored preference happened to be `ko`, the toggle wrongly showed **KO** as active, which made clicking feel like a no-op. The active highlight now reflects the **page's own language** on post detail pages (`/ko/posts/*` ⇒ KO, `/posts/*` ⇒ EN), falling back to the saved preference elsewhere. Also excluded `/posts/page/*` pagination from the post-switch.

Verified locally against a GitHub-Pages-equivalent static serve: EN↔KO round-trips correctly on post pages (English `/posts/<slug>` ⇄ Korean `/ko/posts/<slug>`), the active state matches the page, and the cursor is a pointer.

Note: by design the site UI is English-only — the toggle switches the **article** on post pages and sets a reading preference that makes post links open in that language elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)