### PR TITLE
fix(i18n): render Korean home tagline in 42dot Sans

### DIFF
--- a/components/home/Masthead.tsx
+++ b/components/home/Masthead.tsx
@@ -2,9 +2,11 @@
 
 import siteMetadata from '@/data/siteMetadata'
 import { useUI } from '@/components/useUI'
+import { useLanguage } from '@/components/LanguageProvider'
 
 export default function Masthead() {
   const ui = useUI()
+  const { lang } = useLanguage()
   return (
     <section className="pt-12 pb-16 sm:pt-16">
       <p className="eyebrow mb-5">{ui.masthead.eyebrow}</p>
@@ -13,7 +15,10 @@ export default function Masthead() {
         <br />
         LEE<span className="text-accent">.</span>
       </h1>
-      <p className="text-ink/90 mt-7 max-w-[24ch] font-serif text-2xl leading-[1.4]">
+      <p
+        className="text-ink/90 mt-7 max-w-[24ch] font-serif text-2xl leading-[1.4]"
+        style={lang === 'ko' ? { fontFamily: "'42dot Sans', sans-serif" } : undefined}
+      >
         {ui.masthead.tagline}
       </p>
       <div className="mt-8 flex flex-wrap gap-6 font-mono text-sm">


### PR DESCRIPTION
Make the home hero tagline render in **42dot Sans** when the reading language is Korean.

The tagline uses the `font-serif` utility, which in this Tailwind v4 setup resolves to the default serif stack (Georgia → system Korean font) rather than the custom `--font-family-serif` (`--font-family-*` isn't Tailwind v4's `--font-*` namespace). So the Korean tagline fell back to a system font instead of 42dot Sans.

Apply `font-family: '42dot Sans'` to the tagline only when KO is selected; English keeps the existing serif styling.

Verified on the static export with Playwright: in KO the tagline computes to `"42dot Sans", sans-serif` and loads the 42dot Korean subsets; in EN it is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)