### PR TITLE
fix(i18n): all Korean serif text renders in 42dot Sans

### DIFF
--- a/components/home/Masthead.tsx
+++ b/components/home/Masthead.tsx
@@ -2,11 +2,9 @@
 
 import siteMetadata from '@/data/siteMetadata'
 import { useUI } from '@/components/useUI'
-import { useLanguage } from '@/components/LanguageProvider'
 
 export default function Masthead() {
   const ui = useUI()
-  const { lang } = useLanguage()
   return (
     <section className="pt-12 pb-16 sm:pt-16">
       <p className="eyebrow mb-5">{ui.masthead.eyebrow}</p>
@@ -15,10 +13,7 @@ export default function Masthead() {
         <br />
         LEE<span className="text-accent">.</span>
       </h1>
-      <p
-        className="text-ink/90 mt-7 max-w-[24ch] font-serif text-2xl leading-[1.4]"
-        style={lang === 'ko' ? { fontFamily: "'42dot Sans', sans-serif" } : undefined}
-      >
+      <p className="text-ink/90 mt-7 max-w-[24ch] font-serif text-2xl leading-[1.4]">
         {ui.masthead.tagline}
       </p>
       <div className="mt-8 flex flex-wrap gap-6 font-mono text-sm">

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -5,6 +5,11 @@
   --font-family-mono: var(--font-jetbrains), '42dot Sans', ui-monospace, monospace;
   --font-family-serif: var(--font-newsreader), '42dot Sans', Georgia, serif;
 
+  /* Tailwind v4 builds the font-serif utility from the --font-* namespace. Map it to
+     the editorial serif stack (which includes 42dot Sans) so Korean text in `font-serif`
+     spots renders in 42dot Sans instead of a system serif (Batang) fallback. */
+  --font-serif: var(--font-newsreader), '42dot Sans', Georgia, serif;
+
   /* Rust accent ramp (replaces Professional Blue) */
   --color-primary-50: #fef6f0;
   --color-primary-100: #fde8da;


### PR DESCRIPTION
Follow-up to #101. The home tagline was fixed, but every other `font-serif` spot (project & career descriptions, post summaries, writing intro, list summaries, about bio paragraphs) still rendered Korean in a system serif (Batang) font.

Root cause: Tailwind v4 builds the `font-serif` utility from the `--font-*` namespace, but the project only defined `--font-family-serif`, so `font-serif` resolved to the default serif stack (no 42dot Sans).

Add `--font-serif` to `@theme` → `var(--font-newsreader), '42dot Sans', Georgia, serif`. Now:
- English serif text uses **Newsreader** (the design's intended body serif)
- Korean serif text uses **42dot Sans**, site-wide

The per-element tagline override from #101 is removed (no longer needed).

Verified on the static export: tagline, writing intro, project descriptions and career descriptions all compute to `Newsreader … "42dot Sans" …` and render Korean in 42dot Sans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)